### PR TITLE
Update so MV plugin filenames end with MV

### DIFF
--- a/rollup.mjs
+++ b/rollup.mjs
@@ -111,7 +111,7 @@ const outputOptions = {
         return await fs.readFile(`./src/${dir}/Params.js`, "utf8");
       },
       name: exportName ? exportName : "",
-      file: `${OUTPUT_DIR}/mv/js/plugins/Luna_${dir}.js`,
+      file: `${OUTPUT_DIR}/mv/js/plugins/Luna_${dir}MV.js`,
       ...outputOptions,
     });
   });


### PR DESCRIPTION
This will help with the nightly build release assets filenames including long numbers due to same filenames.